### PR TITLE
API Bump for 3.0.X

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -3,4 +3,4 @@ author: JackNoordhuis
 description: Limits the amount of item entities in your server by adding item drops straight to entities inventories
 version: 0.0.9
 main: jacknoordhuis\autoinv\AutoInv
-api: [3.0.0-ALPHA7, 3.0.0-ALPHA8, 3.0.0-ALPHA9, 3.0.0-ALPHA10, 3.0.0-ALPHA11, 3.0.0-ALPHA12]
+api: [3.0.0-ALPHA7, 3.0.0-ALPHA8, 3.0.0-ALPHA9, 3.0.0-ALPHA10, 3.0.0-ALPHA11, 3.0.0-ALPHA12, 3.0.0]


### PR DESCRIPTION
This was tested on a clean server running 
```PocketMine-MP 3.0.6+dev for Minecraft: PE v1.4.0 (protocol version 261)```

Code did not appear to need any modifications for compatibility and worked as expected in game.