### PR TITLE
Fixing duplication bug

### DIFF
--- a/src/jacknoordhuis/autoinv/event/handle/BlockBreakPickup.php
+++ b/src/jacknoordhuis/autoinv/event/handle/BlockBreakPickup.php
@@ -34,6 +34,7 @@ class BlockBreakPickup extends EventHandler {
 	 * @param BlockBreakEvent $event
 	 */
 	public function handleBlockBreak(BlockBreakEvent $event) : void {
+		if($event->isCancelled()) return;
 		foreach($event->getDrops() as $drop) {
 			$event->getPlayer()->getInventory()->addItem($drop);
 		}


### PR DESCRIPTION
When a plugin cancels BlockBreakEvent, the item loots still added to player's inventory. This means that the block will not get destroyed but the loots still added to player's inventory. This pull request fixes the bug.